### PR TITLE
Use https:// url for rebar3 instead of git.

### DIFF
--- a/src/reo3impl.d
+++ b/src/reo3impl.d
@@ -71,7 +71,7 @@ system_default=
 color=true
 
 [Repos]
-default=git@github.com:rebar/rebar3.git
+default=https://github.com/rebar/rebar3.git
 
 [Rebar3s]
 none =


### PR DESCRIPTION
 Otheriwise sometimes during cloning of rebar3 would see "The authenticity of host github.com
 could not be established. Are you sure you want to continue (yes/no)?"
