### PR TITLE
Add std.getopt.config.keepEndOfOptions to erln8impl.d

### DIFF
--- a/src/erln8impl.d
+++ b/src/erln8impl.d
@@ -124,6 +124,7 @@ osx_gcc_env=CC=gcc-4.2 CPPFLAGS='-DNDEBUG' MAKEFLAGS='-j 3'k
         auto rslt = getopt(
             args,
             std.getopt.config.passThrough,
+            std.getopt.config.keepEndOfOptions,
             "use",           "Setup the current directory to use a specific verion of Erlang", &opts.opt_use,
             "list",          "List available Erlang installations",      &opts.opt_list,
             "remote",        "add/delete/show remotes", &opts.opt_remote,


### PR DESCRIPTION
I'm not entirely sure why I didn't see this issue before, but after performing a clean install of OS X El Capitan, I have been experiencing some odd behavior with `erln8` passing the correct arguments to the actual `erl` script.

The bug broke all of my [`erlang.mk`](https://github.com/ninenines/erlang.mk) based projects, which I'll reference at the bottom for others who have the issue, but first I'll explain the reduced issue.
##### Reduced Issue

Here's how you might reproduce the issue:

First, install a version of OTP (may not be necessary if you use the test repo) and replace `erl` with a simple shell script that just `echo` the arguments passed to it.

``` bash
erln8 --build OTP-18.1
cd ~/.erln8.d/otps/OTP-18.1
mv erl erl.orig
cat > erl <<-'END'
#!/bin/sh
exec echo ${1+"$@"}
END
chmod +x erl
```

Now call `erl` with any sort of `[...] -- ...` pattern, for example `erl -- a`:

``` bash
erl -- a
# outputs: a a
```

See how the `--` is being dropped and the last argument is being duplicated?

If, however, you specify an option that `getopt` recognizes in `erln8impl.d`, the `--` is preserved:

``` bash
erl --debug -- a
# outputs: --debug -- a
```

Interesting side-note, the duplication effect happens with whatever the last argument happens to be after the `--` if there are more than one:

``` bash
erl -- a b
# outputs: a b b
```

Anyway, all this pull request does is add [`std.getopt.config.keepEndOfOptions`](http://dlang.org/library/std/getopt/config.keep_end_of_options.html) in combination with [`std.getopt.config.passThrough`](http://dlang.org/library/std/getopt/config.pass_through.html).

With this change, we get the following in the shell:

``` bash
erl -- a
# outputs: -- a
```

I'm not sure whether this would be considered a bug in [`std/getopt.d`](https://github.com/D-Programming-Language/phobos/blob/master/std/getopt.d) or not.
##### Original erlang.mk Issue

The exact error I was experiencing with `erlang.mk` was:

``` bash
mkdir myapp
cd myapp
wget https://raw.githubusercontent.com/ninenines/erlang.mk/master/erlang.mk
make -f erlang.mk bootstrap
make

# outputs:
#  DEPEND myapp.d
# (no error logger present) error: <0.0.0>
# 
# Crash dump is being written to: erl_crash.dump...done
# System process <0.0.0> terminated: {function_clause,[{init,prepare_run_args,[{eval,[<<9,69,114,108,70,...,97,108,116,40,41>>,<<"erlang.mk">>,<<"erlang.mk">>]}],[]},{init,map,2,[]},{init,boot,1,[]}]}
# make: *** [myapp.d] Error 1
```
